### PR TITLE
Make sure eqMac volume is always handled

### DIFF
--- a/Volume Protector/VolumeProtector.swift
+++ b/Volume Protector/VolumeProtector.swift
@@ -10,20 +10,21 @@ import SimplyCoreAudio
 import os
 
 @main
-struct main {
+struct Main {
     static func main() {
         logger.info("Greetings from Volume Protector!")
-        
+
         guard let userOptions = getUserOptions() else { print(usageString); return }
-        
+
         logger.info("Device: \"\(userOptions.targetDeviceName, privacy: .public)\"")
         logger.info("Default Volume: \"\(userOptions.defaultVolume, privacy: .public)\"")
         logger.info("Dangerous Volume: \"\(userOptions.dangerousVolume, privacy: .public)\"")
         logger.info("Channel: \"\(userOptions.deviceChannel, privacy: .public)\"")
-        logger.info("Scope: \"\(str2scope.first(where: { $0.value == userOptions.deviceScope })!.key, privacy: .public)\"")
-        
+        guard let scopeStr = str2scope.first(where: { $0.value == userOptions.deviceScope })?.key else { return }
+        logger.info("Scope: \"\(scopeStr, privacy: .public)\"")
+
         _ = createDeviceListChangedObserver(userOptions: userOptions)
-        
+
         RunLoop.main.run()
     }
 }

--- a/Volume Protector/helpers.swift
+++ b/Volume Protector/helpers.swift
@@ -10,7 +10,11 @@ import SimplyCoreAudio
 import os
 
 let simplyCA = SimplyCoreAudio()
-var volumeChangeObservers:[NSObjectProtocol] = []
+var observers: [NSObjectProtocol] = []
+var targetDeviceVolumeobserver: NSObjectProtocol?
+var eqMacNameObserver: NSObjectProtocol?
+var eqMacVolumeObserver: NSObjectProtocol?
+var defaultDeviceObserver: NSObjectProtocol?
 
 let logger = Logger(subsystem: "dev.jeng.Volume-Protector", category: "earSafety")
 
@@ -20,7 +24,7 @@ let str2scope = [
     "input": Scope.input,
     "main": Scope.main,
     "playthrough": Scope.playthrough,
-    "wildcard": Scope.wildcard,
+    "wildcard": Scope.wildcard
 ]
 
 struct Options {
@@ -54,51 +58,112 @@ func getUserOptions() -> Options? {
     guard let defaultVolume = args.popLast()?.float32 else { print("<default-volume> is not Float32."); return nil }
     guard let dangerousVolume = args.popLast()?.float32 else { print("<dangerous-volume> is not Float32."); return nil }
     guard let deviceChannel = args.popLast()?.uint32 else { print("<channel> is not UInt32."); return nil }
-    guard let deviceScope: Scope = args.popLast().flatMap({str2scope[$0]}) else { print("<scope> is not a valid scope."); return nil }
+    guard let deviceScope = args.popLast().flatMap({str2scope[$0]}) else { print("<scope> is invalid."); return nil }
     guard args.isEmpty else { print("Too many arguments!"); return nil }
-    
-    return Options(targetDeviceName: targetDeviceName, defaultVolume: defaultVolume, dangerousVolume: dangerousVolume, deviceChannel: deviceChannel, deviceScope: deviceScope)
+
+    return Options(
+        targetDeviceName: targetDeviceName,
+        defaultVolume: defaultVolume,
+        dangerousVolume: dangerousVolume,
+        deviceChannel: deviceChannel,
+        deviceScope: deviceScope)
 }
 
 func createVolumeChangeObserver(device: AudioDevice, userOptions: Options) -> NSObjectProtocol {
-    return NotificationCenter.default.addObserver(forName: .deviceVolumeDidChange, object: device, queue: .main) { (notification) in
+    return NotificationCenter.default.addObserver(forName: .deviceVolumeDidChange,
+                                                   object: device,
+                                                    queue: .main) { (notification) in
         guard let channel = notification.userInfo?["channel"] as? UInt32 else { return }
         guard let scope = notification.userInfo?["scope"] as? Scope else { return }
         guard let volume = device.volume(channel: channel, scope: scope) else { return }
         logger.info("Volume of \"\(device.name, privacy: .public)\" was altered to \(volume * 100)%")
         if volume > userOptions.dangerousVolume {
             device.setVolume(userOptions.defaultVolume, channel: channel, scope: scope)
-            logger.info("WARNING: Volume reduced to \(userOptions.defaultVolume * 100)% from DANGEROUS volume \(volume * 100)% for \"\(device.name, privacy: .public)\"!")
+            logger.info("WARNING: Volume reduced to \(userOptions.defaultVolume * 100)%")
+            logger.info("from DANGEROUS volume \(volume * 100)% for \"\(device.name, privacy: .public)\"!")
         }
     }
 }
 
-func deviceListChangedHandler(userOptions: Options) -> Void {
-    let deviceList = simplyCA.allDevices
-    var newVolumeChangeObservers:[NSObjectProtocol] = []
-    
-    if let targetDevice = deviceList.first(where: { $0.name == userOptions.targetDeviceName }) {
-        let eqMacDevice = deviceList.first(where: { $0.name.contains("eqMac") })
-        let targetDevices = [targetDevice, eqMacDevice].compactMap { $0 }
-        for device in targetDevices {
-            logger.info("Setting volume for \"\(device.name, privacy: .public)\" to a default value of \(userOptions.defaultVolume * 100)%")
-            device.setVolume(userOptions.defaultVolume, channel: userOptions.deviceChannel, scope: userOptions.deviceScope)
-            logger.info("Starting volume observer for \"\(device.name, privacy: .public)\".")
-            newVolumeChangeObservers.append(
-                createVolumeChangeObserver(device: device, userOptions: userOptions)
-            )
+func eqMacHandler(userOptions: Options, eqMacDevice: AudioDevice? = nil) {
+    let deviceList: [AudioDevice] = simplyCA.allDevices
+    guard let device: AudioDevice = eqMacDevice ?? deviceList.first(where: { $0.name.contains("eqMac") }) else {
+        if defaultDeviceObserver == nil {
+            defaultDeviceObserver = createDefaultDeviceObserver(userOptions: userOptions)
+        }
+        return
+    }
+    if let deviceObserver = defaultDeviceObserver {
+        NotificationCenter.default.removeObserver(deviceObserver)
+        defaultDeviceObserver = nil
+    }
+    let deviceName: String = device.name
+    logger.info("eqMac virtual device found.\(deviceName, privacy: .public)")
+    if eqMacNameObserver == nil {
+        eqMacNameObserver = createEQMacObserver(eqMacDevice: device, userOptions: userOptions)
+    }
+    if deviceName.contains(userOptions.targetDeviceName) {
+        logger.info("eqMac output device is the target device.")
+        if eqMacVolumeObserver == nil {
+            eqMacVolumeObserver = createVolumeChangeObserver(device: device, userOptions: userOptions)
+        }
+    } else {
+        if let volumeObserver = eqMacVolumeObserver {
+            NotificationCenter.default.removeObserver(volumeObserver)
+            eqMacVolumeObserver = nil
         }
     }
-    while let observer = volumeChangeObservers.popLast() {
+}
+
+func createEQMacObserver(eqMacDevice: AudioDevice, userOptions: Options) -> NSObjectProtocol {
+    return NotificationCenter.default.addObserver(forName: .deviceNameDidChange,
+                                                   object: eqMacDevice,
+                                                    queue: .main) { (_) in
+        eqMacHandler(userOptions: userOptions, eqMacDevice: eqMacDevice)
+        logger.info("Name changed.\(eqMacDevice.name)")
+    }
+}
+
+func createDefaultDeviceObserver(userOptions: Options) -> NSObjectProtocol {
+    return NotificationCenter.default.addObserver(forName: .defaultOutputDeviceChanged,
+                                                   object: nil,
+                                                    queue: .main) { (_) in
+        if let device: AudioDevice = simplyCA.defaultOutputDevice {
+            let deviceName: String = device.name
+            if deviceName.contains("eqMac") {
+                eqMacHandler(userOptions: userOptions, eqMacDevice: device)
+            }
+        }
+        logger.info("Default output changed.\(simplyCA.defaultOutputDevice!.name)")
+    }
+}
+
+func targetDeviceHandler(userOptions: Options) {
+    let deviceList = simplyCA.allDevices
+    var newObservers: [NSObjectProtocol] = []
+
+    if let device = deviceList.first(where: { $0.name == userOptions.targetDeviceName }) {
+        logger.info("Setting volume for \"\(device.name, privacy: .public)\"")
+        logger.info("to a default value of \(userOptions.defaultVolume * 100)%")
+        device.setVolume(userOptions.defaultVolume, channel: userOptions.deviceChannel, scope: userOptions.deviceScope)
+        logger.info("Starting volume observer for \"\(device.name, privacy: .public)\".")
+        newObservers.append(createVolumeChangeObserver(device: device, userOptions: userOptions))
+    }
+
+    while let observer = observers.popLast() {
         logger.info("Removing volume observer.")
         NotificationCenter.default.removeObserver(observer)
     }
-    volumeChangeObservers = newVolumeChangeObservers
+    observers = newObservers
 }
 
 func createDeviceListChangedObserver(userOptions: Options) -> NSObjectProtocol {
-    deviceListChangedHandler(userOptions: userOptions)
-    return NotificationCenter.default.addObserver(forName: .deviceListChanged, object: nil, queue: .main) { (notification) in
-        deviceListChangedHandler(userOptions: userOptions)
+    targetDeviceHandler(userOptions: userOptions)
+    eqMacHandler(userOptions: userOptions)
+    return NotificationCenter.default.addObserver(forName: .deviceListChanged,
+                                                   object: nil,
+                                                    queue: .main) { (_) in
+        targetDeviceHandler(userOptions: userOptions)
+        eqMacHandler(userOptions: userOptions)
     }
 }


### PR DESCRIPTION
In some cases, eqMac's virtual device volume is not handled properly. Mainly when the target device is plugged in, but not selected in eqMac, it will still attempt to change eqMac's volume thus changing the volume of a device that is not targeted.

Changing eqMac's volume is purely cosmetic as far as I can tell, however I want to stay at the safe side and handle that too, thus the attempt at fixing this issue.

The code is still not all that great looking, will try to do some refactoring later.